### PR TITLE
dst with no args lists todos; --help shows usage

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -62,12 +62,14 @@ let list_todos todos =
 
 let usage () =
   print_endline "Usage:";
-  print_endline "  todo add \"task text\"";
-  print_endline "  todo list";
-  print_endline "  todo done <number>"
+  print_endline "  dst add \"task text\"";
+  print_endline "  dst list";
+  print_endline "  dst done <number>"
 
 let () =
   match Array.to_list Sys.argv with
+  | [ _ ] -> list_todos (load_todos ())
+  | [ _; "--help" ] -> usage ()
   | [ _; "add"; text ] -> add_todo text
   | [ _; "list" ] -> list_todos (load_todos ())
   | [ _; "done"; n ] -> (


### PR DESCRIPTION
## Summary
- `dst` (no args) now prints the todo list instead of the usage block.
- `dst --help` prints the usage.
- Other unrecognized args still fall through to usage (preserved).
- Fixed the usage strings to say `dst` instead of `todo` (the actual installed binary name).

## Test plan
- [x] `dune build` clean
- [x] `dune exec dst -- --help` prints usage with `dst`
- [x] `dune exec dst -- bogus` falls through to usage

Closes #1