### PR TITLE
Add dst delete <n> to remove a todo

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -60,11 +60,18 @@ let list_todos todos =
   save_todos updated;
   Printf.printf "Marked #%d done\n" n
 
+let delete n =
+  let todos = load_todos () in
+  let updated = todos |> List.filteri (fun i _ -> i + 1 <> n) in
+  save_todos updated;
+  Printf.printf "Deleted #%d\n" n
+
 let usage () =
   print_endline "Usage:";
   print_endline "  todo add \"task text\"";
   print_endline "  todo list";
-  print_endline "  todo done <number>"
+  print_endline "  todo done <number>";
+  print_endline "  dst delete <number>"
 
 let () =
   match Array.to_list Sys.argv with
@@ -73,6 +80,10 @@ let () =
   | [ _; "done"; n ] -> (
       match int_of_string_opt n with
       | Some n -> mark_done n
+      | None -> usage ())
+  | [ _; "delete"; n ] -> (
+      match int_of_string_opt n with
+      | Some n -> delete n
       | None -> usage ())
   | _ -> usage ()
 


### PR DESCRIPTION
## Summary
- New `delete` function and `dst delete <n>` match arm.
- Mirrors `mark_done`: `List.filteri` filter, silent no-op on out-of-range.
- Updated `usage ()` to include the new command.

## Test plan
- [x] `dune build` clean
- [ ] Smoke: add A/B/C, delete 2, list shows A/C
- [ ] `delete 99` no-ops (matches mark_done behavior)

Closes #3