### PR TITLE
Add alcotest unit suite for Todo serialize/deserialize

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,28 +1,13 @@
-(* A simple todo object *)
-type todo = {
-  text : string;
-  completed : bool;
-}
+open Dead_simple_todos
 
 (* File on disk that holds the todos. *)
 let file = "/Users/niru/.todo.txt"
-
-(* Convert todo type to text representation. *)
-let serialize_todo todo =
-  let status = if todo.completed then "1" else "0" in
-  status ^ "\t" ^ todo.text
-
-(* Convert text representation to todo type. *)
-let deserialize_todo line =
-  match String.split_on_char '\t' line with
-    | [ status; text ] -> { completed = status = "1"; text }
-    | _ -> { completed = false; text = line }
 
 (* Load todos from file. *)
 let load_todos () =
   if Sys.file_exists file then
     In_channel.with_open_text file In_channel.input_lines
-    |> List.map deserialize_todo
+    |> List.map Todo.deserialize
   else
     []
 
@@ -30,7 +15,7 @@ let load_todos () =
 let save_todos todos =
   let contents =
     todos
-    |> List.map serialize_todo
+    |> List.map Todo.serialize
     |> String.concat "\n"
   in
   Out_channel.with_open_text file (fun oc ->
@@ -40,10 +25,10 @@ let save_todos todos =
 (* Add todo to the file. *)
 let add_todo text =
   let todos = load_todos () in
-  save_todos (todos @ [ { text; completed = false } ]);
+  save_todos (todos @ [ { Todo.text; completed = false } ]);
   Printf.printf "Added: %s\n" text
 
-let print_todo index todo =
+let print_todo index (todo : Todo.t) =
   let mark = if todo.completed then "x" else " " in
   Printf.printf "%d. [%s] %s\n" index mark todo.text
 
@@ -54,7 +39,7 @@ let list_todos todos =
   let todos = load_todos () in
   let updated =
     todos
-    |> List.mapi (fun i todo ->
+    |> List.mapi (fun i (todo : Todo.t) ->
       if i + 1 = n then { todo with completed = true } else todo)
   in
   save_todos updated;
@@ -75,4 +60,3 @@ let () =
       | Some n -> mark_done n
       | None -> usage ())
   | _ -> usage ()
-

--- a/dead_simple_todos.opam
+++ b/dead_simple_todos.opam
@@ -12,6 +12,7 @@ bug-reports: "https://github.com/username/reponame/issues"
 depends: [
   "dune" {>= "3.22"}
   "ocaml"
+  "alcotest" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
  (name dead_simple_todos)
  (synopsis "A short synopsis")
  (description "A longer description")
- (depends ocaml)
+ (depends ocaml (alcotest :with-test))
  (tags
   ("add topics" "to describe" your project)))
 

--- a/lib/todo.ml
+++ b/lib/todo.ml
@@ -1,0 +1,16 @@
+(* A simple todo object. *)
+type t = {
+  text : string;
+  completed : bool;
+}
+
+(* Convert todo type to text representation. *)
+let serialize todo =
+  let status = if todo.completed then "1" else "0" in
+  status ^ "\t" ^ todo.text
+
+(* Convert text representation to todo type. *)
+let deserialize line =
+  match String.split_on_char '\t' line with
+  | [ status; text ] -> { completed = status = "1"; text }
+  | _ -> { completed = false; text = line }

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,3 @@
 (test
  (name test_dead_simple_todos)
- (libraries dead_simple_todos))
+ (libraries dead_simple_todos alcotest))

--- a/test/test_dead_simple_todos.ml
+++ b/test/test_dead_simple_todos.ml
@@ -1,0 +1,70 @@
+open Dead_simple_todos
+
+(* Custom Alcotest testable for Todo.t so failures pretty-print and
+   equality is structural. *)
+let todo_testable =
+  let pp fmt (t : Todo.t) =
+    Format.fprintf fmt "{ completed = %b; text = %S }" t.completed t.text
+  in
+  let eq (a : Todo.t) (b : Todo.t) =
+    a.completed = b.completed && a.text = b.text
+  in
+  Alcotest.testable pp eq
+
+let test_round_trip_completed () =
+  let todo = { Todo.text = "buy milk"; completed = true } in
+  Alcotest.check todo_testable
+    "round-trip preserves completed=true"
+    todo
+    (Todo.deserialize (Todo.serialize todo))
+
+let test_round_trip_not_completed () =
+  let todo = { Todo.text = "write tests"; completed = false } in
+  Alcotest.check todo_testable
+    "round-trip preserves completed=false"
+    todo
+    (Todo.deserialize (Todo.serialize todo))
+
+let test_deserialize_completed_with_text () =
+  Alcotest.check todo_testable
+    "1<TAB>hello world parses as completed=true"
+    { Todo.completed = true; text = "hello world" }
+    (Todo.deserialize "1\thello world")
+
+let test_deserialize_empty_text () =
+  Alcotest.check todo_testable
+    "0<TAB> with empty text parses as not-completed empty"
+    { Todo.completed = false; text = "" }
+    (Todo.deserialize "0\t")
+
+let test_deserialize_no_tab () =
+  Alcotest.check todo_testable
+    "line without a tab is treated as raw text, not completed"
+    { Todo.completed = false; text = "no-tab-line" }
+    (Todo.deserialize "no-tab-line")
+
+let test_serialize_completed () =
+  Alcotest.(check string)
+    "serialize completed prefixes 1<TAB>"
+    "1\tdone task"
+    (Todo.serialize { Todo.text = "done task"; completed = true })
+
+let () =
+  Alcotest.run "dead_simple_todos"
+    [
+      ( "Todo serialize/deserialize",
+        [
+          Alcotest.test_case "round-trip completed=true" `Quick
+            test_round_trip_completed;
+          Alcotest.test_case "round-trip completed=false" `Quick
+            test_round_trip_not_completed;
+          Alcotest.test_case "deserialize 1<TAB>hello world" `Quick
+            test_deserialize_completed_with_text;
+          Alcotest.test_case "deserialize 0<TAB>" `Quick
+            test_deserialize_empty_text;
+          Alcotest.test_case "deserialize no-tab line" `Quick
+            test_deserialize_no_tab;
+          Alcotest.test_case "serialize completed" `Quick
+            test_serialize_completed;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Extracts pure helpers (`type t`, `serialize`, `deserialize`) from `bin/main.ml` into `lib/todo.ml` so they're testable.
- Adds `alcotest` as a `:with-test` dependency (`dune-project` + regenerated `.opam`).
- Adds 6 alcotest unit tests covering round-trips and edge cases (empty text, no-tab line, etc.).
- Run with `dune test`.

**Conflicts with #2**: PR #2 moves more of the module into the library. Reviewer should resolve at merge time — either land #2 first and rebase this on top, or land this first and adjust #2 to keep the alcotest changes.

## Test plan
- [x] `dune build` clean
- [x] `dune test` — all 6 cases pass
- [x] `dune exec dst -- list` still works

Closes #5